### PR TITLE
[compiler-rt][sanitizer_common] Generalize CheckNoDeepBind as OnDlOpen

### DIFF
--- a/compiler-rt/lib/asan/asan_interceptors.cpp
+++ b/compiler-rt/lib/asan/asan_interceptors.cpp
@@ -163,7 +163,7 @@ DECLARE_REAL_AND_INTERCEPTOR(void, free, void*)
     ({                                              \
       if (flags()->strict_init_order)               \
         StopInitOrderChecking();                    \
-      CheckNoDeepBind(filename, flag);              \
+      OnDlOpen(filename, flag);                     \
       REAL(dlopen)(filename, flag);                 \
     })
 #  define COMMON_INTERCEPTOR_ON_EXIT(ctx) OnExit()

--- a/compiler-rt/lib/sanitizer_common/sanitizer_common.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_common.h
@@ -1094,7 +1094,7 @@ const s32 kReleaseToOSIntervalNever = -1;
 
 // Platform hook invoked before dlopen. Performs platform-specific dlopen flag
 // checks (e.g. RTLD_DEEPBIND on Linux).
-void OnDlOpen(const char *filename, int flag);
+void OnDlOpen(const char* filename, int flag);
 
 // Returns the requested amount of random data (up to 256 bytes) that can then
 // be used to seed a PRNG. Defaults to blocking like the underlying syscall.

--- a/compiler-rt/lib/sanitizer_common/sanitizer_common.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_common.h
@@ -1092,7 +1092,9 @@ struct StackDepotStats {
 // indicate that sanitizer allocator should not attempt to release memory to OS.
 const s32 kReleaseToOSIntervalNever = -1;
 
-void CheckNoDeepBind(const char *filename, int flag);
+// Platform hook invoked before dlopen. Performs platform-specific dlopen flag
+// checks (e.g. RTLD_DEEPBIND on Linux).
+void OnDlOpen(const char *filename, int flag);
 
 // Returns the requested amount of random data (up to 256 bytes) that can then
 // be used to seed a PRNG. Defaults to blocking like the underlying syscall.

--- a/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors.inc
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors.inc
@@ -277,8 +277,11 @@ extern const short *_tolower_tab_;
       common_flags()->strict_string_checks ? (internal_strlen(s)) + 1 : (n) )
 
 #ifndef COMMON_INTERCEPTOR_DLOPEN
-#define COMMON_INTERCEPTOR_DLOPEN(filename, flag) \
-  ({ CheckNoDeepBind(filename, flag); REAL(dlopen)(filename, flag); })
+#  define COMMON_INTERCEPTOR_DLOPEN(filename, flag) \
+    ({                                              \
+      OnDlOpen(filename, flag);                     \
+      REAL(dlopen)(filename, flag);                 \
+    })
 #endif
 
 #ifndef COMMON_INTERCEPTOR_GET_TLS_RANGE

--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
@@ -2867,7 +2867,7 @@ void CheckMPROTECT() {
 #  endif
 }
 
-void CheckNoDeepBind(const char *filename, int flag) {
+void OnDlOpen(const char *filename, int flag) {
 #  ifdef RTLD_DEEPBIND
   if (flag & RTLD_DEEPBIND) {
     Report(

--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
@@ -2867,7 +2867,25 @@ void CheckMPROTECT() {
 #  endif
 }
 
-void OnDlOpen(const char *filename, int flag) {
+#  if SANITIZER_AMDGPU
+void PatchHsaRuntimeDlopenFlag(const char* filename, int& flag) {
+  if (filename &&
+      (internal_strstr(filename, "libamdhip64.so") ||
+       internal_strstr(filename, "libhsa-runtime64.so") ||
+       internal_strstr(filename, "libamdocl64.so")) &&
+      !(flag & RTLD_GLOBAL)) {
+    flag |= RTLD_GLOBAL;
+    if (Verbosity() >= 2) {
+      Printf(
+          "RTLD_GLOBAL flag on dlopen call forced on for %s due to AMDGPU "
+          "device sanitizer runtime requirements.\n",
+          filename);
+    }
+  }
+}
+#  endif
+
+void OnDlOpen(const char* filename, int flag) {
 #  ifdef RTLD_DEEPBIND
   if (flag & RTLD_DEEPBIND) {
     Report(
@@ -2879,6 +2897,10 @@ void OnDlOpen(const char *filename, int flag) {
         filename, filename);
     Die();
   }
+#  endif
+
+#  if SANITIZER_AMDGPU
+  PatchHsaRuntimeDlopenFlag(filename, flag);
 #  endif
 }
 

--- a/compiler-rt/lib/sanitizer_common/sanitizer_mac.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_mac.cpp
@@ -1533,7 +1533,7 @@ void DumpProcessMap() {
   Printf("End of module map.\n");
 }
 
-void CheckNoDeepBind(const char *filename, int flag) {
+void OnDlOpen(const char *filename, int flag) {
   // Do nothing.
 }
 

--- a/compiler-rt/lib/sanitizer_common/sanitizer_mac.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_mac.cpp
@@ -1533,7 +1533,7 @@ void DumpProcessMap() {
   Printf("End of module map.\n");
 }
 
-void OnDlOpen(const char *filename, int flag) {
+void OnDlOpen(const char* filename, int flag) {
   // Do nothing.
 }
 

--- a/compiler-rt/lib/sanitizer_common/sanitizer_win.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_win.cpp
@@ -1222,7 +1222,7 @@ int WaitForProcess(pid_t pid) { return -1; }
 // FIXME implement on this platform.
 void GetMemoryProfile(fill_profile_f cb, uptr *stats) {}
 
-void CheckNoDeepBind(const char *filename, int flag) {
+void OnDlOpen(const char *filename, int flag) {
   // Do nothing.
 }
 

--- a/compiler-rt/lib/sanitizer_common/sanitizer_win.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_win.cpp
@@ -1222,7 +1222,7 @@ int WaitForProcess(pid_t pid) { return -1; }
 // FIXME implement on this platform.
 void GetMemoryProfile(fill_profile_f cb, uptr *stats) {}
 
-void OnDlOpen(const char *filename, int flag) {
+void OnDlOpen(const char* filename, int flag) {
   // Do nothing.
 }
 

--- a/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp
@@ -2596,9 +2596,9 @@ static void HandleRecvmsg(ThreadState *thr, uptr pc,
 
 #define COMMON_INTERCEPTOR_DLOPEN(filename, flag) \
   ({                                              \
-    CheckNoDeepBind(filename, flag);              \
+    OnDlOpen(filename, flag);                     \
     ThreadIgnoreBegin(thr, 0);                    \
-    void *res = REAL(dlopen)(filename, flag);     \
+    void* res = REAL(dlopen)(filename, flag);     \
     ThreadIgnoreEnd(thr);                         \
     res;                                          \
   })


### PR DESCRIPTION
[compiler-rt][sanitizer_common] Generalize CheckNoDeepBind as OnDlOpen

Rename the dlopen pre-check hook to OnDlOpen so platform-specific dlopen
handling can be extended beyond the RTLD_DEEPBIND guard on Linux.
Windows and macOS keep no-op implementations. All dlopen interceptors
call the shared hook.

[compiler-rt][sanitizer_linux] Force RTLD_GLOBAL for HSA/HIP/OpenCL
runtime dlopen.

  - When ASan intercepts dlopen of libamdhip64.so, libhsa-runtime64.so,
    or libamdocl64.so, add RTLD_GLOBAL if it was omitted, so symbols are
    visible as required by the AMDGPU device sanitizer runtime.

  - Add PatchHsaRuntimeDlopenFlag in sanitizer_common/sanitizer_linux
    and call it from the dlopen interceptor.